### PR TITLE
Avoid extra indirection in the OCaml version

### DIFF
--- a/treebench.ml
+++ b/treebench.ml
@@ -1,6 +1,6 @@
 type tree =
   | Leaf of int
-  | Node of (tree * tree)
+  | Node of tree * tree
 
 let build_tree (n : int) : tree =
   let rec go root n =


### PR DESCRIPTION
```ocaml
type t = Foo of (bar * baz)
```
is the same as 
```ocaml
type t' = (bar * baz)
type t = Foo of t'
```

It uses one extra indirection for a pair. Removing the parens remove the indirection and make the representation more flat.

The perf difference is tiny, though.